### PR TITLE
Add support for dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ steps:
     # (Optional) Use conventional commit messages. Default is false.
     # See https://www.conventionalcommits.org. 
     conventional_commits: true
+    # (Optional) Do not make actual changes on dev.to.
+    dry_run: false
 ```
 
 You can use [this template repository](https://github.com/sinedied/devto-github-template) as an example setup.

--- a/action.yml
+++ b/action.yml
@@ -26,3 +26,7 @@ inputs:
     description: 'Use conventional commits messages'
     required: false
     default: false
+  dry_run:
+    description: 'Do not make actual changes on dev.to'
+    required: false
+    default: false

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ async function run() {
     const filesGlob = core.getInput('files');
     const branch = core.getInput('branch');
     const useConventionalCommits = core.getInput('conventional_commits');
+    const dryRun = core.getInput('dry_run');
 
     core.setSecret(devtoKey);
     core.setSecret(githubToken);
@@ -18,7 +19,8 @@ async function run() {
         githubToken,
         filesGlob,
         branch,
-        useConventionalCommits
+        useConventionalCommits,
+        dryRun
       })
     );
 
@@ -27,7 +29,8 @@ async function run() {
       devtoKey,
       githubToken,
       branch,
-      useConventionalCommits
+      useConventionalCommits,
+      dryRun
     });
   } catch (error) {
     core.setFailed(error.toString());

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -9,7 +9,8 @@ export async function publishArticles(options) {
     devtoKey: options.devtoKey || process.env.DEVTO_TOKEN,
     repo,
     branch: options.branch,
-    checkImages: true
+    checkImages: true,
+    dryRun: options.dryRun
   });
 
   if (!results || results.length === 0) {


### PR DESCRIPTION
Adds support for the dry-run setting of the CLI.

I thought it might be interesting to have support for it as well, during builds when reviewing PRs.
I haven't been able to test it since I'm not familiar with the process for github actions.

I'm not sure if there are other modifications needed in order to not push anything as a git commit.