### PR TITLE
adds dry-run support and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ steps:
     # (Optional) Use conventional commit messages. Default is false.
     # See https://www.conventionalcommits.org. 
     conventional_commits: true
+    # (Optional) Do not make actual changes on dev.to.
+    dry_run: false
 ```
 
 You can use [this template repository](https://github.com/sinedied/devto-github-template) as an example setup.
@@ -38,6 +40,7 @@ You can use [this template repository](https://github.com/sinedied/devto-github-
 ## Using a custom committer
 
 You can specify who you want to appear in the commits made by this action by adding these environment variables to the action:
+
 ```yaml
   env:
     GIT_COMMITTER_NAME: your_name

--- a/action.yml
+++ b/action.yml
@@ -26,3 +26,12 @@ inputs:
     description: 'Use conventional commits messages'
     required: false
     default: false
+  dry_run:
+    description: 'Do not make actual changes on dev.to'
+    required: false
+    default: false
+outputs:
+  result_json:
+    description: 'Result as a json string'
+  result_summary_table_json:
+    description: 'Summary of actions formatted as a table'

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -9,11 +9,24 @@ export async function publishArticles(options) {
     devtoKey: options.devtoKey || process.env.DEVTO_TOKEN,
     repo,
     branch: options.branch,
-    checkImages: true
+    checkImages: true,
+    dryRun: options.dryRun
   });
 
   if (!results || results.length === 0) {
-    return;
+    return [];
+  }
+
+  const output = results.map((r) => ({
+    status: r.status,
+    publishedStatus: r.publishedStatus,
+    title: r.article.data.title,
+    id: r.article.data.id
+  }));
+
+  if (options.dryRun) {
+    console.log('Running in dry run mode, skipping commit step.');
+    return output;
   }
 
   const shouldCommit = results.some(
@@ -34,4 +47,6 @@ export async function publishArticles(options) {
   } else {
     console.log('No detected changes, skipping commit step.');
   }
+
+  return output;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "publish-devto",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.3",
-        "@sinedied/devto-cli": "^1.1.0"
+        "@sinedied/devto-cli": "^1.1.0",
+        "table": "^6.8.0"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.31.1",
@@ -4588,11 +4590,6 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6333,12 +6330,11 @@
       }
     },
     "node_modules/table": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "dependencies": {
         "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.3",
@@ -10305,11 +10301,6 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11534,12 +11525,11 @@
       }
     },
     "table": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "requires": {
         "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.3",
-    "@sinedied/devto-cli": "^1.1.0"
+    "@sinedied/devto-cli": "^1.1.0",
+    "table": "^6.8.0"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.31.1",
@@ -55,7 +56,8 @@
   },
   "prettier": {
     "trailingComma": "none",
-    "bracketSpacing": true
+    "bracketSpacing": true,
+    "endOfLine": "auto"
   },
   "engines": {
     "node": "^14.13.1 || >=16.0.0",


### PR DESCRIPTION
Adds support for the dry-run CLI option, as well as output parameters to the github action. The new outputs are 2:
1. The stringified JSON of the CLI output
2. A table-like structured output of the CLI results

One comment:
When doing a dry-run, if you run it on a PR branch, articles which have no actual changes will still show up as changed, given that the source of the image URLs include the branch name and it will be different between a branch and main.

Given that I've manually moved the changes from another fork you might want to give it a try before merging, to make sure nothing breaks.